### PR TITLE
125 use of self in class functions and self type

### DIFF
--- a/bytecode/src/context.rs
+++ b/bytecode/src/context.rs
@@ -286,6 +286,10 @@ impl<'a> Ctx<'a> {
         self.stack.push(var);
     }
 
+    pub(crate) fn push_front(&mut self, var: Primitive) {
+        self.stack.insert(0, var);
+    }
+
     /// Pop an item from the local operating stack.
     pub(crate) fn pop(&mut self) -> Option<Primitive> {
         self.stack.pop()

--- a/bytecode/src/context.rs
+++ b/bytecode/src/context.rs
@@ -283,6 +283,10 @@ impl<'a> Ctx<'a> {
         self.call_stack.borrow_mut().register_variable(name, var)
     }
 
+    pub(crate) fn ref_variable(&self, name: Cow<'static, str>, var: Rc<RefCell<(Primitive, VariableFlags)>>) {
+        self.call_stack.borrow_mut().ref_variable(name, var)
+    }
+
     /// Store a variable to the top of the call stack *only*. Will get dropped when the stack frame goes out of scope.
     pub(crate) fn register_variable_local(&self, name: String, var: Primitive) -> Result<()> {
         self.call_stack.borrow_mut().register_variable_local(name, var, VariableFlags::none())
@@ -305,6 +309,12 @@ impl<'a> Ctx<'a> {
     /// Will start the search in the current function and bubble all the way up to the highest stack frame.
     pub(crate) fn load_variable(&self, name: &str) -> Option<Rc<RefCell<(Primitive, VariableFlags)>>> {
         self.call_stack.borrow().find_name(name)
+    }
+
+    pub(crate) fn load_self_export(&self, name: &str) -> Option<Rc<RefCell<(Primitive, VariableFlags)>>> {
+        let file = self.function.location().upgrade().expect("could not upgrade reference to file");
+
+        file.get_export(name)
     }
 
     /// Get a reference to all of the variables mapped to this function.

--- a/bytecode/src/file.rs
+++ b/bytecode/src/file.rs
@@ -192,7 +192,6 @@ impl MScriptFile {
 
     pub fn get_export(&self, name: &str) -> Option<Rc<RefCell<(Primitive, VariableFlags)>>> {
         let exports = self.exports.borrow();
-        dbg!(&exports);
         exports.get(name)
     }
 

--- a/bytecode/src/file.rs
+++ b/bytecode/src/file.rs
@@ -190,6 +190,12 @@ impl MScriptFile {
         view.update_once(name, var).context("Double export: name is already exported")
     }
 
+    pub fn get_export(&self, name: &str) -> Option<Rc<RefCell<(Primitive, VariableFlags)>>> {
+        let exports = self.exports.borrow();
+        dbg!(&exports);
+        exports.get(name)
+    }
+
 
     /// Get all the functions associated with this file.
     ///

--- a/bytecode/src/instruction.rs
+++ b/bytecode/src/instruction.rs
@@ -492,8 +492,6 @@ pub mod implementations {
 
             let function_ptr = PrimitiveFunction::new(location.into(), callback_state);
 
-            // dbg!(&function_ptr);
-
             ctx.push(function!(function_ptr));
 
             Ok(())
@@ -680,8 +678,6 @@ pub mod implementations {
                 let destination = JumpRequestDestination::Standard(f.location().clone());
 
                 let callback_state = f.callback_state().clone();
-
-                // dbg!(&callback_state);
 
                 ctx.signal(InstructionExitState::JumpRequest(JumpRequest {
                     destination,

--- a/bytecode/src/instruction.rs
+++ b/bytecode/src/instruction.rs
@@ -972,6 +972,20 @@ pub mod implementations {
 
         }
 
+        ld_self(ctx, args) {
+            let Some(name) = args.get(0) else {
+                bail!("`ld_self` requires a name argument");
+            };
+
+            let Some(var) = ctx.load_local(name) else {
+                bail!("load before store (`{name}` not in this stack frame)\nframe `{}`'s variables:\n{}", ctx.rced_call_stack().borrow().get_frame_label(), ctx.get_frame_variables())
+            };
+
+            ctx.push_front(var.borrow().0.clone());
+
+            Ok(())
+        }
+
         assert(ctx, args) {
             if ctx.stack_size() != 1 {
                 bail!("assert can only operate on a single item");

--- a/bytecode/src/instruction_constants.rs
+++ b/bytecode/src/instruction_constants.rs
@@ -22,7 +22,7 @@ pub static REPR_TO_BIN: Lazy<HashMap<&[u8], u8>> = Lazy::new(|| {
 ///
 /// Saving this as a constant makes it harder for the arrays to fall out of sync
 /// by requiring that they both take the same size.
-pub const INSTRUCTION_COUNT: usize = 59;
+pub const INSTRUCTION_COUNT: usize = 61;
 
 /// This is an array that provides O(1) lookups of names from bytes.
 pub static BIN_TO_REPR: [&[u8]; INSTRUCTION_COUNT] = [
@@ -85,6 +85,8 @@ pub static BIN_TO_REPR: [&[u8]; INSTRUCTION_COUNT] = [
     /* 0x38 [56] */ b"reserve_primitive",
     /* 0x39 [57] */ b"lookup",
     /* 0x3A [58] */ b"ld_self",
+    /* 0x3B [59] */ b"export_name",
+    /* 0x3C [60] */ b"export_special",
 ];
 
 /// Similar to [`BIN_TO_REPR`][crate::instruction_constants::BIN_TO_REPR],
@@ -149,6 +151,8 @@ pub static FUNCTION_POINTER_LOOKUP: [InstructionSignature; INSTRUCTION_COUNT] = 
     implementations::reserve_primitive,
     implementations::lookup,
     implementations::ld_self,
+    implementations::export_name,
+    implementations::export_special,
 ];
 
 pub mod id {
@@ -214,4 +218,6 @@ pub mod id {
     pub const RESERVE_PRIMITIVE: u8 = 56;
     pub const LOOKUP: u8 = 57;
     pub const LD_SELF: u8 = 58;
+    pub const EXPORT_NAME: u8 = 59;
+    pub const EXPORT_SELF: u8 = 60;
 }

--- a/bytecode/src/instruction_constants.rs
+++ b/bytecode/src/instruction_constants.rs
@@ -22,7 +22,7 @@ pub static REPR_TO_BIN: Lazy<HashMap<&[u8], u8>> = Lazy::new(|| {
 ///
 /// Saving this as a constant makes it harder for the arrays to fall out of sync
 /// by requiring that they both take the same size.
-pub const INSTRUCTION_COUNT: usize = 58;
+pub const INSTRUCTION_COUNT: usize = 59;
 
 /// This is an array that provides O(1) lookups of names from bytes.
 pub static BIN_TO_REPR: [&[u8]; INSTRUCTION_COUNT] = [
@@ -84,6 +84,7 @@ pub static BIN_TO_REPR: [&[u8]; INSTRUCTION_COUNT] = [
     /* 0x37 [55] */ b"assert",
     /* 0x38 [56] */ b"reserve_primitive",
     /* 0x39 [57] */ b"lookup",
+    /* 0x3A [58] */ b"ld_self",
 ];
 
 /// Similar to [`BIN_TO_REPR`][crate::instruction_constants::BIN_TO_REPR],
@@ -147,6 +148,7 @@ pub static FUNCTION_POINTER_LOOKUP: [InstructionSignature; INSTRUCTION_COUNT] = 
     implementations::assert,
     implementations::reserve_primitive,
     implementations::lookup,
+    implementations::ld_self,
 ];
 
 pub mod id {
@@ -211,4 +213,5 @@ pub mod id {
     pub const ASSERT: u8 = 55;
     pub const RESERVE_PRIMITIVE: u8 = 56;
     pub const LOOKUP: u8 = 57;
+    pub const LD_SELF: u8 = 58;
 }

--- a/bytecode/src/instruction_constants.rs
+++ b/bytecode/src/instruction_constants.rs
@@ -22,7 +22,7 @@ pub static REPR_TO_BIN: Lazy<HashMap<&[u8], u8>> = Lazy::new(|| {
 ///
 /// Saving this as a constant makes it harder for the arrays to fall out of sync
 /// by requiring that they both take the same size.
-pub const INSTRUCTION_COUNT: usize = 61;
+pub const INSTRUCTION_COUNT: usize = 62;
 
 /// This is an array that provides O(1) lookups of names from bytes.
 pub static BIN_TO_REPR: [&[u8]; INSTRUCTION_COUNT] = [
@@ -87,6 +87,7 @@ pub static BIN_TO_REPR: [&[u8]; INSTRUCTION_COUNT] = [
     /* 0x3A [58] */ b"ld_self",
     /* 0x3B [59] */ b"export_name",
     /* 0x3C [60] */ b"export_special",
+    /* 0x3D [61] */ b"load_self_export",
 ];
 
 /// Similar to [`BIN_TO_REPR`][crate::instruction_constants::BIN_TO_REPR],
@@ -153,6 +154,7 @@ pub static FUNCTION_POINTER_LOOKUP: [InstructionSignature; INSTRUCTION_COUNT] = 
     implementations::ld_self,
     implementations::export_name,
     implementations::export_special,
+    implementations::load_self_export,
 ];
 
 pub mod id {
@@ -220,4 +222,5 @@ pub mod id {
     pub const LD_SELF: u8 = 58;
     pub const EXPORT_NAME: u8 = 59;
     pub const EXPORT_SELF: u8 = 60;
+    pub const LOAD_SELF_EXPORT: u8 = 61;
 }

--- a/bytecode/src/lib.rs
+++ b/bytecode/src/lib.rs
@@ -14,6 +14,7 @@ mod variables;
 
 // Alternate naming to make writing FFI functions simpler.
 pub use function::ReturnValue as FFIReturnValue;
+pub(crate) use variables::Primitive;
 pub use variables::Primitive as BytecodePrimitive;
 
 // Expose the Program interface.

--- a/bytecode/src/stack.rs
+++ b/bytecode/src/stack.rs
@@ -289,6 +289,12 @@ impl Stack {
         self.register_variable_flags(name, var, VariableFlags::none())
     }
 
+    pub fn ref_variable(&mut self, name: Cow<'static, str>, var: Rc<RefCell<(Primitive, VariableFlags)>>) {
+        let stack_frame = self.0.last_mut().expect("nothing in the stack");
+        let variables = &mut stack_frame.variables.0;
+        variables.insert(name.into_owned(), var);
+    }
+
     /// Add a `name -> variable` mapping to the current stack frame, with flags.
     pub fn register_variable_local(
         &mut self,

--- a/bytecode/src/stack.rs
+++ b/bytecode/src/stack.rs
@@ -1,6 +1,7 @@
 //! Program call stack
 
 use anyhow::{anyhow, bail, Context, Result};
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
@@ -22,6 +23,11 @@ pub(crate) mod flag_constants {
 pub struct VariableFlags(pub(crate) u8);
 
 impl VariableFlags {
+    #[inline(always)]
+    pub const fn new_public() -> Self {
+        Self(flag_constants::PUBLIC)
+    }
+
     #[inline(always)]
     pub fn none() -> Self {
         VariableFlags(0)
@@ -70,7 +76,7 @@ impl Debug for VariableFlags {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Clone)]
+#[derive(Default, Debug, PartialEq)]
 pub struct VariableMapping(HashMap<String, Rc<RefCell<(Primitive, VariableFlags)>>>);
 
 impl Display for VariableMapping {
@@ -112,8 +118,21 @@ impl VariableMapping {
         self.0.get(key).cloned()
     }
 
+    /// Explicit clone, because this is probably not intented behavior.
+    pub fn clone(instance: &Self) -> Self {
+        Self(instance.0.clone())
+    }
+
     pub fn contains(&self, key: &str) -> bool {
         self.0.contains_key(key)
+    }
+
+    pub fn update_once(&mut self, name: String, value: Rc<RefCell<(Primitive, VariableFlags)>>) -> Result<()> {
+        if let Some(export) = self.0.insert(name, value) {
+            bail!("value already present: {export:?}");
+        }
+
+        Ok(())
     }
 
     /// Update the value of a variable that has already been registered.
@@ -266,7 +285,7 @@ impl Stack {
     }
 
     /// Add a `name -> variable` mapping to the current stack frame, possibly searching, with default flags.
-    pub fn register_variable(&mut self, name: String, var: Primitive) -> Result<()> {
+    pub fn register_variable(&mut self, name: Cow<'static, str>, var: Primitive) -> Result<()> {
         self.register_variable_flags(name, var, VariableFlags::none())
     }
 
@@ -296,7 +315,7 @@ impl Stack {
     /// Add a `name -> variable` mapping to the current stack frame, with special flags.
     pub fn register_variable_flags(
         &mut self,
-        name: String,
+        name: Cow<'static, str>,
         var: Primitive,
         flags: VariableFlags,
     ) -> Result<()> {
@@ -326,7 +345,7 @@ impl Stack {
             }
         }
 
-        self.register_variable_local(name, var, flags)?;
+        self.register_variable_local(name.into_owned(), var, flags)?;
 
         Ok(())
     }

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -49,7 +49,7 @@ pub(crate) use value::{CompileTimeEvaluate, ConstexprEvaluation, Value};
 pub(crate) use while_loop::WhileLoop;
 
 #[allow(unused)]
-pub(crate) use r#type::{BIGINT_TYPE, BOOL_TYPE, BYTE_TYPE, FLOAT_TYPE, INT_TYPE, STR_TYPE};
+pub(crate) use r#type::{BIGINT_TYPE, BOOL_TYPE, BYTE_TYPE, FLOAT_TYPE, INT_TYPE, STR_TYPE, SELF_TYPE};
 
 use anyhow::{anyhow, bail, Context, Error, Result};
 use bytecode::compilation_bridge::{raw_byte_instruction_to_string_representation, Instruction};

--- a/compiler/src/ast/assignment.rs
+++ b/compiler/src/ast/assignment.rs
@@ -139,7 +139,7 @@ impl Dependencies for Assignment {
             }
         }
 
-        dbg!(result)
+        result
     }
 }
 
@@ -330,9 +330,11 @@ impl Parser {
 
         let user_data = input.user_data();
 
+        let self_type = user_data.get_type_of_executing_class();
+
         let (mut x, did_exist_before) = match assignment.as_rule() {
             Rule::assignment_no_type => Self::assignment_no_type(assignment, is_const, is_modify)?,
-            Rule::assignment_type => Self::assignment_type(assignment, is_const, is_modify)?,
+            Rule::assignment_type => Self::assignment_type(assignment, is_const, is_modify, self_type)?,
             Rule::assignment_unpack => Self::assignment_unpack(assignment, is_const, is_modify)?,
             rule => unreachable!("{rule:?}"),
         };

--- a/compiler/src/ast/assignment.rs
+++ b/compiler/src/ast/assignment.rs
@@ -97,9 +97,6 @@ impl Assignment {
 impl Dependencies for Assignment {
     fn supplies(&self) -> Vec<Dependency> {
         if let Self::Single { ident, .. } = self {
-            if ident.name() == "x" {
-                dbg!(ident);
-            }
             if !self.flags().contains(AssignmentFlag::modify()) {
                 return vec![Dependency::new(Cow::Borrowed(ident))];
             }
@@ -169,7 +166,6 @@ impl Compile for Assignment {
 
         match self {
             Self::Single { ident, .. } => {
-                // dbg!(ident);
                 let name = ident.name();
                 let store_instruction = if self.flags().contains(AssignmentFlag::modify()) {
                     instruction!(store_object name)
@@ -330,7 +326,8 @@ impl Parser {
 
         let user_data = input.user_data();
 
-        let self_type = user_data.get_type_of_executing_class();
+        // We can't borrow a `Ref` here, because `rvalue` portion might borrow the call stack mutably. 
+        let self_type = user_data.get_owned_type_of_executing_class();
 
         let (mut x, did_exist_before) = match assignment.as_rule() {
             Rule::assignment_no_type => Self::assignment_no_type(assignment, is_const, is_modify)?,

--- a/compiler/src/ast/assignment/assignment_type.rs
+++ b/compiler/src/ast/assignment/assignment_type.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::cell::Ref;
 
 use anyhow::Result;
 
@@ -13,7 +12,7 @@ impl Parser {
         input: Node,
         is_const: bool,
         is_modify: bool,
-        self_type: Option<Ref<ClassType>>
+        self_type: Option<ClassType>
     ) -> Result<(Assignment, bool), Vec<anyhow::Error>> {
         let mut children = input.children();
 
@@ -35,7 +34,7 @@ impl Parser {
         let value: Value = Self::value(value)?;
 
         if let Ok(ref assignment_ty) = value.for_type() {
-            if !ty.as_ref().get_type_recursively().eq_complex(assignment_ty.get_type_recursively(), self_type) {
+            if !ty.as_ref().get_type_recursively().eq_complex(assignment_ty.get_type_recursively(), self_type.as_ref()) {
                 let hint = ty.get_error_hint_between_types(assignment_ty).map_or_else(
                     || Cow::Borrowed(""),
                     |str| Cow::Owned(format!("\n\t- hint: {str}")),

--- a/compiler/src/ast/assignment/assignment_type.rs
+++ b/compiler/src/ast/assignment/assignment_type.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
+use std::cell::Ref;
 
 use anyhow::Result;
 
+use crate::ast::ClassType;
 use crate::ast::{new_err, r#type::IntoType, Assignment, Ident, TypeLayout, Value};
 use crate::parser::{Node, Parser};
 use crate::VecErr;
@@ -11,6 +13,7 @@ impl Parser {
         input: Node,
         is_const: bool,
         is_modify: bool,
+        self_type: Option<Ref<ClassType>>
     ) -> Result<(Assignment, bool), Vec<anyhow::Error>> {
         let mut children = input.children();
 
@@ -32,7 +35,7 @@ impl Parser {
         let value: Value = Self::value(value)?;
 
         if let Ok(ref assignment_ty) = value.for_type() {
-            if ty.as_ref().get_type_recursively() != assignment_ty.get_type_recursively() {
+            if !ty.as_ref().get_type_recursively().eq_complex(assignment_ty.get_type_recursively(), self_type) {
                 let hint = ty.get_error_hint_between_types(assignment_ty).map_or_else(
                     || Cow::Borrowed(""),
                     |str| Cow::Owned(format!("\n\t- hint: {str}")),

--- a/compiler/src/ast/callable.rs
+++ b/compiler/src/ast/callable.rs
@@ -86,7 +86,7 @@ impl Compile for Callable<'_> {
         };
 
         if let Some(name) = self_register {
-            args_init.insert(0, instruction!(load_fast name));
+            args_init.push(instruction!(ld_self name));
         }
 
         // let func_name = ident.name();

--- a/compiler/src/ast/class.rs
+++ b/compiler/src/ast/class.rs
@@ -42,8 +42,8 @@ impl Compile for Class {
         let body_compiled = self.body.compile(state)?;
 
         let TypeLayout::Class(ty) = self.ident.ty()?.as_ref() else {
-			unreachable!()
-		};
+            unreachable!()
+        };
 
         let id = CompiledFunctionId::Custom(format!("{}_{}", ty.name(), ty.id));
 
@@ -68,10 +68,23 @@ impl Compile for Class {
 pub(crate) struct ClassType {
     name: Arc<String>,
     fields: Arc<[Ident]>,
+    path_str: Arc<String>,
     id: usize,
 }
 
 impl ClassType {
+    pub(crate) fn abs_id(&self) -> String {
+        format!("{}_{}", self.name, self.id)
+    }
+
+    pub(crate) fn abs_class_path(&self) -> String {
+        format!("{}#", self.path_str)
+    }
+
+    pub(crate) fn initialization_callable_path(&self) -> String {
+        format!("{}#{}_{}", self.path_str, self.name, self.id)
+    }
+
     pub fn constructor(&self) -> FunctionType {
         for field in self.fields() {
             if field.name() == "$constructor" {
@@ -160,6 +173,7 @@ impl Parser {
 
             let class_type = ClassType {
                 fields,
+                path_str: input.user_data().get_file_name(),
                 name: Arc::new(ident.name().to_owned()),
                 id: input.user_data().request_class_id(),
             };

--- a/compiler/src/ast/class/constructor.rs
+++ b/compiler/src/ast/class/constructor.rs
@@ -159,7 +159,7 @@ impl Parser {
         let body = children.next().unwrap();
         let body = Self::block(body)?;
 
-        let class_type = input.user_data().get_type_of_executing_class().unwrap();
+        let class_type = input.user_data().get_owned_type_of_executing_class().unwrap();
 
         let path_str = input.user_data().get_file_name();
 

--- a/compiler/src/ast/class/constructor.rs
+++ b/compiler/src/ast/class/constructor.rs
@@ -112,7 +112,7 @@ impl Compile for Constructor {
 impl WalkForType for Constructor {
     fn type_from_node(input: &Node) -> Result<Ident> {
         let parameters = input.children().next().unwrap();
-        let parameters = Parser::function_parameters(parameters, false, true)?;
+        let parameters = Parser::function_parameters(parameters, false, true, true)?;
 
         let function_type = FunctionType::new(Arc::new(parameters), ScopeReturnStatus::Void);
 
@@ -154,7 +154,7 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(ScopeReturnStatus::Void);
 
-        let parameters = Self::function_parameters(parameters, true, true).to_err_vec()?;
+        let parameters = Self::function_parameters(parameters, true, true, true).to_err_vec()?;
 
         let body = children.next().unwrap();
         let body = Self::block(body)?;

--- a/compiler/src/ast/class/member_function.rs
+++ b/compiler/src/ast/class/member_function.rs
@@ -75,8 +75,6 @@ impl Compile for MemberFunction {
 
         let arguments = arguments.into_boxed_slice();
 
-        // dbg!(&arguments);
-
         let make_function_instruction = CompiledItem::Instruction {
             id: MAKE_FUNCTION,
             arguments,

--- a/compiler/src/ast/class/member_function.rs
+++ b/compiler/src/ast/class/member_function.rs
@@ -94,7 +94,7 @@ impl WalkForType for MemberFunction {
         let mut ident = Parser::ident(ident_node)?;
 
         let parameters_node = children.next().unwrap();
-        let parameters = Parser::function_parameters(parameters_node, false, true)?;
+        let parameters = Parser::function_parameters(parameters_node, false, true, true)?;
 
         let maybe_return_type_node = children.next().unwrap();
 
@@ -155,7 +155,7 @@ impl Parser {
         // Using "_" or not saving it as a variable causes the scope to pop instantly.
         let _scope_handle = input.user_data().push_function(return_type.clone());
 
-        let parameters = Self::function_parameters(parameters, true, true).to_err_vec()?;
+        let parameters = Self::function_parameters(parameters, true, true, true).to_err_vec()?;
         let body = Self::block(body)?;
         let function_type = FunctionType::new(Arc::new(parameters.clone()), return_type);
 

--- a/compiler/src/ast/class/member_function.rs
+++ b/compiler/src/ast/class/member_function.rs
@@ -161,7 +161,7 @@ impl Parser {
 
         ident.set_type_no_link(Cow::Owned(TypeLayout::Function(function_type)));
 
-        let class_type = input.user_data().get_type_of_executing_class().unwrap();
+        let class_type = input.user_data().get_owned_type_of_executing_class().unwrap();
 
         Ok(MemberFunction {
             ident,

--- a/compiler/src/ast/dot_lookup.rs
+++ b/compiler/src/ast/dot_lookup.rs
@@ -144,7 +144,7 @@ impl Parser {
                 let output_type = if output_type.is_class_self() {
                     lhs_ty
                 } else {
-                    &output_type
+                    output_type
                 };
 
                 Ok(DotLookup {

--- a/compiler/src/ast/dot_lookup.rs
+++ b/compiler/src/ast/dot_lookup.rs
@@ -132,7 +132,7 @@ impl Parser {
 
                 assert_eq!(arguments.as_rule(), Rule::function_arguments);
 
-                let arguments = Self::function_arguments(arguments, function_type.parameters())?;
+                let arguments = Self::function_arguments(arguments, function_type.parameters(), Some(lhs_ty))?;
 
                 let lookup_type = DotLookupOption::FunctionCall {
                     function_name: ident_str,

--- a/compiler/src/ast/dot_lookup.rs
+++ b/compiler/src/ast/dot_lookup.rs
@@ -139,12 +139,17 @@ impl Parser {
                     arguments,
                 };
 
+                let output_type = function_type.return_type().get_type().unwrap_or(&Cow::Owned(TypeLayout::Void));
+
+                let output_type = if output_type.is_class_self() {
+                    lhs_ty
+                } else {
+                    &output_type
+                };
+
                 Ok(DotLookup {
                     lookup_type,
-                    output_type: function_type
-                        .return_type()
-                        .get_type()
-                        .unwrap_or(&Cow::Owned(TypeLayout::Void)),
+                    output_type,
                 })
             }
             Rule::dot_name_lookup => Ok(DotLookup {

--- a/compiler/src/ast/function.rs
+++ b/compiler/src/ast/function.rs
@@ -35,6 +35,10 @@ impl FunctionType {
         &self.return_type
     }
 
+    pub(crate) fn set_return_type(&mut self, new_status: ScopeReturnStatus) {
+        *self.return_type = new_status;
+    }
+
     pub fn parameters(&self) -> &FunctionParameters {
         &self.parameters
     }

--- a/compiler/src/ast/function.rs
+++ b/compiler/src/ast/function.rs
@@ -321,7 +321,7 @@ impl Parser {
             // so the parameters MUST never be used. Essentially, we are just
             // syntax checks.
             let parameters =
-                Self::function_parameters(parameters, false, false).map_err(|e| vec![anyhow!(e)])?;
+                Self::function_parameters(parameters, false, false, false).map_err(|e| vec![anyhow!(e)])?;
 
             return Ok(Function::new(
                 Arc::new(parameters),
@@ -348,7 +348,7 @@ impl Parser {
             .user_data()
             .push_function(ScopeReturnStatus::detect_should_return(return_type));
 
-        let parameters = Arc::new(Self::function_parameters(parameters, true, false).to_err_vec()?);
+        let parameters = Arc::new(Self::function_parameters(parameters, true, false, false).to_err_vec()?);
 
         // input.user_data().register_function_parameters_to_scope(Arc::clone(&parameters));
 

--- a/compiler/src/ast/function_parameters.rs
+++ b/compiler/src/ast/function_parameters.rs
@@ -156,7 +156,8 @@ impl Parser {
             ident.link_force_no_inherit(input.user_data(), ty)?;
 
             if add_to_scope_dependencies {
-                input.user_data().add_dependency(&ident);
+
+                // input.user_data().add_dependency(ident);
             }
 
             result.push(ident);

--- a/compiler/src/ast/function_parameters.rs
+++ b/compiler/src/ast/function_parameters.rs
@@ -97,6 +97,7 @@ impl Parser {
         input: Node,
         add_to_scope_dependencies: bool,
         require_self_param: bool,
+        allow_self_type: bool,
     ) -> Result<FunctionParameters> {
         let mut children = input.children();
 
@@ -144,7 +145,13 @@ impl Parser {
                 err()?
             }
 
+            let ty_span = ty.as_span();
+
             let ty: Cow<'static, TypeLayout> = Self::r#type(ty)?;
+
+            if !allow_self_type && ty.is_class_self() {
+                return Err(new_err(ty_span, &input.user_data().get_source_file_name(), "`Self` is only a valid type for associated functions, and not normal functions. (Hint: if trying to accept a callback function, use a function type like `fn(int) -> bool`)".to_owned()));
+            }
 
             ident.link_force_no_inherit(input.user_data(), ty)?;
 

--- a/compiler/src/ast/ident.rs
+++ b/compiler/src/ast/ident.rs
@@ -46,7 +46,7 @@ impl PartialEq for Ident {
 pub static KEYWORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     HashSet::from_iter([
         "fn", "obj", "print", "return", "if", "else", "true", "false", "modify", "const", "self",
-        "while", "continue", "break", "from", "constructor", "class"
+        "while", "continue", "break", "from", "constructor", "class", "Self"
     ])
 });
 

--- a/compiler/src/ast/ident.rs
+++ b/compiler/src/ast/ident.rs
@@ -151,8 +151,6 @@ impl Ident {
 
         self.ty = Some(new_ty);
 
-        dbg!(self);
-
         Ok(())
     }
 

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -236,7 +236,6 @@ impl CompileTimeEvaluate for Expr {
 
 impl IntoType for Expr {
     fn for_type(&self) -> Result<super::TypeLayout> {
-        dbg!(self);
         match self {
             Expr::Value(val) => val.for_type(),
             Expr::BinOp { lhs, op, rhs } => {
@@ -252,14 +251,12 @@ impl IntoType for Expr {
                 })
             }
             Expr::UnaryMinus(val) | Expr::UnaryNot(val) => val.for_type(),
-            Expr::Callable(CallableContents::Standard { function, lhs_raw, .. }) => {
-                dbg!(lhs_raw);
+            Expr::Callable(CallableContents::Standard { function, .. }) => {
                 let return_type = function
                     .return_type()
                     .get_type()
                     .context("function returns void")?;
                 
-                dbg!(return_type);
                 Ok(return_type.clone().into_owned())
             }
             Expr::Callable(CallableContents::ToSelf { return_type, .. }) => {
@@ -643,6 +640,8 @@ fn parse_expr(
                 } else {
                     final_output_type.to_owned()
                 };
+
+                dbg!(&expected_type);
 
                 Ok((Expr::DotLookup { lhs: Box::new(lhs), dot_chain, expected_type }, None))
             }

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -586,7 +586,7 @@ fn parse_expr(
 
                         let parameters = function_type.parameters();
 
-                        let arguments: FunctionArguments = Parser::function_arguments(function_arguments, &parameters, None)?;
+                        let arguments: FunctionArguments = Parser::function_arguments(function_arguments, parameters, None)?;
 
                         // let function_type = function_type.clone();
 
@@ -640,8 +640,6 @@ fn parse_expr(
                 } else {
                     final_output_type.to_owned()
                 };
-
-                dbg!(&expected_type);
 
                 Ok((Expr::DotLookup { lhs: Box::new(lhs), dot_chain, expected_type }, None))
             }

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -53,7 +53,7 @@ use crate::{
 use super::{
     boolean::boolean_from_str, dot_lookup::DotChain, function::FunctionType, list::Index, map_err,
     new_err, r#type::IntoType, CompilationState, Compile, CompileTimeEvaluate, CompiledItem,
-    Dependencies, Dependency, FunctionArguments, TemporaryRegister, TypeLayout, Value,
+    Dependencies, Dependency, FunctionArguments, TemporaryRegister, TypeLayout, Value, ClassType,
 };
 
 pub static PRATT_PARSER: Lazy<PrattParser<Rule>> = Lazy::new(|| {
@@ -136,6 +136,7 @@ pub(crate) enum CallableContents {
 pub(crate) enum Expr {
     Value(Value),
     ReferenceToSelf,
+    ReferenceToConstructor(ClassType),
     UnaryMinus(Box<Expr>),
     UnaryNot(Box<Expr>),
     BinOp {
@@ -207,7 +208,9 @@ impl CompileTimeEvaluate for Expr {
                 let lhs = lhs.try_constexpr_eval()?;
                 let rhs = rhs.try_constexpr_eval()?;
 
-                let (Some(Value::Number(lhs)), Some(Value::Number(rhs))) = (lhs.as_ref(), rhs.as_ref()) else {
+                let (Some(Value::Number(lhs)), Some(Value::Number(rhs))) =
+                    (lhs.as_ref(), rhs.as_ref())
+                else {
                     return Ok(ConstexprEvaluation::Impossible);
                 };
 
@@ -223,6 +226,7 @@ impl CompileTimeEvaluate for Expr {
                 Ok(ConstexprEvaluation::Owned(Value::Number(bin_op_applied?)))
             }
             Self::ReferenceToSelf => Ok(ConstexprEvaluation::Impossible),
+            Self::ReferenceToConstructor(..) => Ok(ConstexprEvaluation::Impossible),
             Self::Callable { .. } => Ok(ConstexprEvaluation::Impossible),
             Self::Index { .. } => Ok(ConstexprEvaluation::Impossible),
             Self::DotLookup { .. } => Ok(ConstexprEvaluation::Impossible),
@@ -262,6 +266,9 @@ impl IntoType for Expr {
                 Ok(return_type.clone().into_owned())
             }
             Expr::ReferenceToSelf => Ok(TypeLayout::ClassSelf),
+            Expr::ReferenceToConstructor(class_type) => {
+                Ok(TypeLayout::Function(class_type.constructor()))
+            }
             Expr::Index { index, .. } => index.for_type(),
             Expr::DotLookup { expected_type, .. } => Ok(expected_type.to_owned()),
         }
@@ -297,6 +304,7 @@ impl Dependencies for Expr {
             }
             E::DotLookup { lhs, .. } => lhs.net_dependencies(),
             E::ReferenceToSelf => vec![],
+            E::ReferenceToConstructor(..) => vec![],
         }
     }
 }
@@ -409,6 +417,9 @@ fn compile_depth(
 
             callable.compile(state)
         }
+        Expr::ReferenceToConstructor(class_type) => {
+            Ok(vec![])
+        }
         Expr::Index { lhs_raw, index } => {
             let mut result = lhs_raw.compile(state)?;
             result.append(&mut index.compile(state)?);
@@ -455,6 +466,17 @@ fn parse_expr(
                             return Ok((Expr::ReferenceToSelf, Some(primary_span)))
                         }
 
+                        if raw_string == "Self" {
+                            let class = user_data
+                                .get_type_of_executing_class()
+                                .details(primary_span, &user_data.get_source_file_name(), "`Self` refers to the constructor of a class, but it is only valid inside the body of said class.")
+                                .to_err_vec()?;
+
+                            let class_ty = class.clone();
+
+                            return Ok((Expr::ReferenceToConstructor(class_ty), Some(primary_span)))
+                        }
+
                         let file_name = user_data.get_file_name();
 
                         let (ident, is_callback) = user_data
@@ -477,20 +499,6 @@ fn parse_expr(
                         Expr::Value(Value::Ident(cloned))
                     }
                     Rule::math_expr => parse_expr(primary.into_inner(), user_data.clone())?,
-                    // Rule::callable => {
-                    //     let x = util::parse_with_userdata_features(
-                    //         Rule::callable,
-                    //         primary.as_str(),
-                    //         user_data.clone(),
-                    //     )
-                    //     .map_err(|e| vec![anyhow!(e)])?;
-
-                    //     let single = x.single().map_err(|e| vec![anyhow!(e)])?;
-
-                    //     let callable = Parser::callable(single)?;
-
-                    //     Expr::Value(Value::Callable(callable))
-                    // }
                     Rule::boolean => {
                         Expr::Value(Value::Boolean(boolean_from_str(primary.as_str())))
                     }
@@ -549,21 +557,41 @@ fn parse_expr(
             Rule::callable => {
                 let (lhs, l_span) = lhs?;
 
-                if let Expr::ReferenceToSelf = lhs {
-                    let return_type = user_data.return_statement_expected_yield_type().map(|x| x.clone());
+                let lhs = Box::new(lhs);
 
-                    let function_arguments: Pair<Rule> = op.into_inner().next().unwrap();
-                    let function_arguments: Node = Node::new_with_user_data(function_arguments, Rc::clone(&user_data));
+                match lhs.as_ref() {
+                    Expr::ReferenceToSelf => {
+                        let return_type = user_data.return_statement_expected_yield_type().map(|x| x.clone());
 
-                    let (_, parameters) = user_data
-                        .get_current_executing_function()
-                        .details(l_span.unwrap(), &user_data.get_source_file_name(), "`self` is not callable here".to_owned())
-                        .to_err_vec()?;
+                        let function_arguments: Pair<Rule> = op.into_inner().next().unwrap();
+                        let function_arguments: Node = Node::new_with_user_data(function_arguments, Rc::clone(&user_data));
 
-                    let arguments: FunctionArguments = Parser::function_arguments(function_arguments, &parameters, None)?;
+                        let (_, parameters) = user_data
+                            .get_current_executing_function()
+                            .details(l_span.unwrap(), &user_data.get_source_file_name(), "`self` is not callable here".to_owned())
+                            .to_err_vec()?;
+
+                        let arguments: FunctionArguments = Parser::function_arguments(function_arguments, &parameters, None)?;
 
 
-                    return Ok((Expr::Callable(CallableContents::ToSelf { return_type, arguments }), None))
+                        return Ok((Expr::Callable(CallableContents::ToSelf { return_type, arguments }), None))
+                    }
+                    Expr::ReferenceToConstructor(ref function_type) => {
+                        let function_arguments: Pair<Rule> = op.into_inner().next().unwrap();
+                        let function_arguments: Node = Node::new_with_user_data(function_arguments, Rc::clone(&user_data));
+
+                        let function_type = function_type.constructor();
+
+                        let parameters = function_type.parameters();
+
+                        let arguments: FunctionArguments = Parser::function_arguments(function_arguments, &parameters, None)?;
+
+                        // let function_type = function_type.clone();
+
+                        return Ok((Expr::Callable(CallableContents::Standard { lhs_raw: lhs, function: function_type, arguments }), None))
+                    
+                    }
+                    _ => ()
                 }
 
                 let lhs_ty = lhs.for_type().to_err_vec()?;
@@ -576,7 +604,7 @@ fn parse_expr(
                 let function_arguments: Node = Node::new_with_user_data(function_arguments, Rc::clone(&user_data));
                 let function_arguments: FunctionArguments = Parser::function_arguments(function_arguments, function_type.parameters(), None)?;
 
-                Ok((Expr::Callable(CallableContents::Standard { lhs_raw: Box::new(lhs), function: function_type, arguments: function_arguments }), None))
+                Ok((Expr::Callable(CallableContents::Standard { lhs_raw: lhs, function: function_type, arguments: function_arguments }), None))
             },
             Rule::list_index => {
                 let lhs = lhs?.0;

--- a/compiler/src/ast/math_expr.rs
+++ b/compiler/src/ast/math_expr.rs
@@ -417,7 +417,7 @@ fn compile_depth(
 
             callable.compile(state)
         }
-        Expr::ReferenceToConstructor(class_type) => {
+        Expr::ReferenceToConstructor(..) => {
             Ok(vec![])
         }
         Expr::Index { lhs_raw, index } => {

--- a/compiler/src/ast/number_loop.rs
+++ b/compiler/src/ast/number_loop.rs
@@ -243,7 +243,7 @@ impl Parser {
                             )
                             .to_err_vec()?;
 
-                        input.user_data().add_dependency(&ident);
+                        // input.user_data().add_dependency(ident.clone());
                         Some(ident)
                     }
                 }

--- a/compiler/src/ast/return.rs
+++ b/compiler/src/ast/return.rs
@@ -91,7 +91,9 @@ impl Parser {
 			)])
 		};
 
-        if expected_return_type != &Cow::Borrowed(supplied_type) {
+        let class_type = input.user_data().get_type_of_executing_class();
+
+        if !expected_return_type.eq_complex(&Cow::Borrowed(supplied_type), class_type) {
             return Err(vec![new_err(
                 input.as_span(),
                 &input.user_data().get_source_file_name(),

--- a/compiler/src/ast/type.rs
+++ b/compiler/src/ast/type.rs
@@ -181,8 +181,8 @@ impl Display for TypeLayout {
             Self::Native(native) => write!(f, "{native}"),
             Self::List(list) => write!(f, "{list}"),
             Self::ValidIndexes(lower, upper) => write!(f, "B({lower}..{upper})"),
-            Self::Class(class_type) => write!(f, "{class_type}"),
-            Self::ClassSelf => write!(f, "self"),
+            Self::Class(class_type) => write!(f, "{}", class_type.name()),
+            Self::ClassSelf => write!(f, "Self"),
             Self::Void => write!(f, "void"),
         }
     }
@@ -201,6 +201,13 @@ impl TypeLayout {
 
         matches!(me, TypeLayout::Native(NativeType::Float))
     }
+
+    pub fn is_class_self(&self) -> bool {
+        let me = self.get_type_recursively();
+
+        matches!(me, TypeLayout::ClassSelf)
+        
+    } 
 
     pub fn get_error_hint_between_types(&self, incompatible: &Self) -> Option<&'static str> {
         use NativeType::*;
@@ -319,7 +326,7 @@ impl TypeLayout {
                 // let fields = fields.map(|x| x.).collect();
 
                 for field in fields {
-                    result.push(field.name().clone());
+                    result.push(field.to_string());
                 }
 
                 result
@@ -354,13 +361,17 @@ impl TypeLayout {
             result.push_str(property);
         }
 
+        if result.is_empty() {
+            result.push_str("<none>")
+        }
+
         let remaining_message = if remaining != 0 {
             Cow::Owned(format!(" (+{remaining} remaining)"))
         } else {
             Cow::Borrowed("")
         };
 
-        format!(" Available properties: {result}{remaining_message}")
+        format!(" Available properties are: [{result}{remaining_message}]")
     }
 
     pub fn can_be_used_as_list_index(&self) -> bool {

--- a/compiler/src/ast/type.rs
+++ b/compiler/src/ast/type.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Display, hash::Hash, sync::Arc};
+use std::{borrow::Cow, fmt::Display, hash::Hash, sync::Arc, cell::Ref};
 
 use crate::{
     ast::{value::ValToUsize, new_err},
@@ -206,8 +206,7 @@ impl TypeLayout {
         let me = self.get_type_recursively();
 
         matches!(me, TypeLayout::ClassSelf)
-        
-    } 
+    }
 
     pub fn get_error_hint_between_types(&self, incompatible: &Self) -> Option<&'static str> {
         use NativeType::*;
@@ -380,6 +379,20 @@ impl TypeLayout {
             TypeLayout::Native(NativeType::Int | NativeType::BigInt)
         )
     }
+
+    pub fn eq_complex(&self, rhs: &Self, executing_class: Option<Ref<ClassType>>) -> bool {
+        if self == rhs {
+            return true;
+        }
+
+        match (self, rhs, executing_class) {
+            (Self::ClassSelf, TypeLayout::Class(other), Some(executing_class)) | (TypeLayout::Class(other), Self::ClassSelf, Some(executing_class)) => {
+                executing_class.eq(&other)
+            },
+            _ => false,
+        }
+
+    } 
 
     pub fn get_output_type_from_index(&self, index: &Value) -> Result<Cow<TypeLayout>> {
         let me = self.get_type_recursively();

--- a/compiler/src/ast/type.rs
+++ b/compiler/src/ast/type.rs
@@ -1,5 +1,4 @@
-use std::{borrow::Cow, fmt::Display, hash::Hash, sync::Arc, cell::Ref};
-
+use std::{borrow::Cow, fmt::Display, hash::Hash, sync::Arc, ops::Deref};
 use crate::{
     ast::{value::ValToUsize, new_err},
     parser::{AssocFileData, Node, Parser, Rule},
@@ -380,14 +379,14 @@ impl TypeLayout {
         )
     }
 
-    pub fn eq_complex(&self, rhs: &Self, executing_class: Option<Ref<ClassType>>) -> bool {
+    pub fn eq_complex(&self, rhs: &Self, executing_class: Option<impl Deref<Target = ClassType>>) -> bool {
         if self == rhs {
             return true;
         }
 
         match (self, rhs, executing_class) {
             (Self::ClassSelf, TypeLayout::Class(other), Some(executing_class)) | (TypeLayout::Class(other), Self::ClassSelf, Some(executing_class)) => {
-                executing_class.eq(&other)
+                executing_class.deref().eq(other)
             },
             _ => false,
         }

--- a/compiler/src/ast/value.rs
+++ b/compiler/src/ast/value.rs
@@ -290,7 +290,7 @@ impl IntoType for Value {
         match self {
             Self::Function(function) => function.for_type(),
             Self::Ident(ident) => Ok(ident.ty()?.clone().into_owned()),
-            Self::MathExpr(math_expr) => math_expr.for_type(),
+            Self::MathExpr(math_expr) => dbg!(math_expr.for_type()),
             Self::Number(number) => number.for_type(),
             Self::String(string) => string.for_type(),
             Self::Boolean(boolean) => boolean.for_type(),

--- a/compiler/src/ast/value.rs
+++ b/compiler/src/ast/value.rs
@@ -290,7 +290,7 @@ impl IntoType for Value {
         match self {
             Self::Function(function) => function.for_type(),
             Self::Ident(ident) => Ok(ident.ty()?.clone().into_owned()),
-            Self::MathExpr(math_expr) => dbg!(math_expr.for_type()),
+            Self::MathExpr(math_expr) => math_expr.for_type(),
             Self::Number(number) => number.for_type(),
             Self::String(string) => string.for_type(),
             Self::Boolean(boolean) => boolean.for_type(),

--- a/compiler/src/grammar.pest
+++ b/compiler/src/grammar.pest
@@ -13,7 +13,11 @@ keywords = _{
     "const" |
     "self" | 
     "while" |
-    "assert"
+    "assert" |
+    "class" |
+    "constructor" |
+    "Self"
+
 }
 
 integer = @{ '0'..'9' ~ ('0'..'9' | ("_" ~ ('0'..'9')))* }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -110,6 +110,10 @@ impl AssocFileData {
         self.scopes.set_self_type_of_class(new_class_type)
     }
 
+    pub fn get_owned_type_of_executing_class(&self) -> Option<ClassType> {
+        self.scopes.get_owned_type_of_executing_class(0)
+    }
+
     pub fn get_type_of_executing_class(&self) -> Option<Ref<ClassType>> {
         self.scopes.get_type_of_executing_class(0)
     }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -330,7 +330,11 @@ pub(crate) mod util {
                         neq => "!=",
                         and => "&&",
                         or => "||",
-                        xor => "^"
+                        xor => "^",
+                        assignment_flag => "assignment flag",
+                        dot_chain => "dot chain",
+                        class_constructor => "constructor",
+                        class_bound_function => "member function",
                     }),
             )
         })

--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::{Borrow, Cow},
-    cell::{Ref, RefCell, RefMut},
+    cell::{Ref, RefCell},
     collections::{HashMap, HashSet},
     fmt::Display,
     sync::Arc,
@@ -155,10 +155,6 @@ impl<'a> std::ops::Deref for SuccessTypeSearchResult<'a> {
 }
 
 impl Scopes {
-    fn borrow_mut(&self) -> RefMut<Vec<Scope>>{
-        self.0.borrow_mut()
-    }
-
     pub(crate) fn new() -> Self {
         log::trace!("INIT Virtual Stack at MODULE");
         Self(RefCell::new(vec![Scope::new_file()]))

--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Result};
 
 use crate::ast::{
     ClassType, FunctionParameters, Ident, TypeLayout, BIGINT_TYPE, BOOL_TYPE, BYTE_TYPE,
-    FLOAT_TYPE, INT_TYPE, STR_TYPE,
+    FLOAT_TYPE, INT_TYPE, STR_TYPE, SELF_TYPE,
 };
 
 #[derive(Debug, Clone, PartialEq, Hash)]
@@ -227,6 +227,7 @@ impl Scopes {
             "bool" => return TypeSearchResult::Ok(Primitive(&BOOL_TYPE)),
             "bigint" => return TypeSearchResult::Ok(Primitive(&BIGINT_TYPE)),
             "byte" => return TypeSearchResult::Ok(Primitive(&BYTE_TYPE)),
+            "Self" => return TypeSearchResult::Ok(Primitive(&SELF_TYPE)),
             _ => (),
         }
 
@@ -459,7 +460,7 @@ impl Scope {
     }
 
     /// able to be improved
-    pub fn contains(&self, dependency: &String) -> Option<&Ident> {
+    pub fn contains(&self, dependency: &str) -> Option<&Ident> {
         // Ident hashes names exclusively, so we can pass `ty = None`
         self.variables.iter().find(|&x| x.name() == dependency)
     }

--- a/compiler/src/tests/class.rs
+++ b/compiler/src/tests/class.rs
@@ -186,3 +186,60 @@ fn self_type() {
 		assert x.play(y) == "Scout is playing with Muna"
 	"#).unwrap();
 }
+
+#[test]
+fn self_type_1() {
+	eval(r#"
+		class A {
+			value: int
+			constructor(self) {
+				self.value = 5
+			}
+			fn make_new_a(self) -> Self {
+				new: Self = Self()
+				new.value = 10
+				return new
+			}
+			fn to_string(self) -> str {
+				return "A("+self.value+")"
+			}
+		}
+	
+		a = A()
+		b = a.make_new_a()
+	
+		assert a.to_string() == "A(5)"
+		assert b.to_string() == "A(10)"
+	"#).unwrap();
+}
+
+#[test]
+fn self_type_2() {
+	eval(r#"
+		class Dog {
+			name: str
+		
+			constructor(self, name: str) {
+				self.name = name
+			}
+	
+			fn play(self, other: Self) -> str {
+				return self.name + " is playing with " + other.name
+			}
+	
+			fn birds_and_bees(self, other: Self) -> Self {
+				baby_name = self.name + " & " + other.name + "'s Baby"
+				return Self(baby_name)
+			}
+		}
+	
+		x = Dog("Scout")
+		y = Dog("Muna")
+		
+		assert x.play(y) == "Scout is playing with Muna"
+	
+		pup = x.birds_and_bees(y)
+	
+		assert pup.name == "Scout & Muna's Baby"
+	"#).unwrap();
+}

--- a/compiler/src/tests/class.rs
+++ b/compiler/src/tests/class.rs
@@ -164,3 +164,25 @@ fn capture_outside_env() {
     )
     .unwrap();
 }
+
+#[test]
+fn self_type() {
+	eval(r#"
+		class Dog {
+			name: str
+		
+			constructor(self, name: str) {
+				self.name = name
+			}
+	
+			fn play(self, other: Self) -> str {
+				return self.name + " is playing with " + other.name
+			}
+		}
+	
+		x = Dog("Scout")
+		y = Dog("Muna")
+	
+		assert x.play(y) == "Scout is playing with Muna"
+	"#).unwrap();
+}

--- a/compiler/src/tests/class.rs
+++ b/compiler/src/tests/class.rs
@@ -243,3 +243,34 @@ fn self_type_2() {
 		assert pup.name == "Scout & Muna's Baby"
 	"#).unwrap();
 }
+
+#[test]
+fn chain() {
+	eval(r#"
+		class D {
+			fn get_value(self) -> int {
+				return 42
+			}
+		}
+	
+		class C {
+			fn d(self) -> D {
+				return D()
+			}
+		}
+	
+		class B {
+			fn c(self) -> C {
+				return C()
+			}
+		}
+	
+		class A {
+			fn b(self) -> B {
+				return B()
+			}
+		}
+	
+		assert (A()).b().c().d().get_value() == 42
+	"#).unwrap();
+}

--- a/examples/main/classes/doggy.ms
+++ b/examples/main/classes/doggy.ms
@@ -1,0 +1,25 @@
+class Dog {
+	name: str
+		
+	constructor(self, name: str) {
+		self.name = name
+	}
+	
+	fn play(self, other: Self) -> str {
+		return self.name + " is playing with " + other.name
+	}
+	
+	fn birds_and_bees(self, other: Self) -> Self {
+		baby_name = self.name + " & " + other.name + "'s Baby"
+		return Self(baby_name)
+	}
+}
+	
+x = Dog("Scout")
+y = Dog("Muna")
+		
+assert x.play(y) == "Scout is playing with Muna"
+	
+pup = x.birds_and_bees(y)
+	
+assert pup.name == "Scout & Muna's Baby"

--- a/examples/main/classes/int_promise.mmm
+++ b/examples/main/classes/int_promise.mmm
@@ -1,0 +1,104 @@
+function Dog_0::play
+	arg 0
+	store self
+	arg 1
+	store other
+	load_fast self
+	lookup name
+	store_fast #1
+	string " is playing with "
+	load_fast #1
+	fast_rev2
+	bin_op +
+	store_fast #0
+	load other
+	lookup name
+	load_fast #0
+	fast_rev2
+	bin_op +
+	printn *
+	void
+	void
+	ret
+end
+function Dog_0::$constructor
+	arg 0
+	store self
+	arg 1
+	store name
+	load name
+	store #0
+	load_fast self
+	lookup name
+	load_fast #0
+	ptr_mut
+	delete_name_scoped #0
+	void
+	ret
+end
+function Dog_0
+	reserve_primitive
+	store_fast name
+	make_function ./int_promise.mmm#Dog_0::play
+	store_fast Dog_0::play
+	make_object
+	store_fast #1
+	make_function ./int_promise.mmm#Dog_0::$constructor
+	store_fast #0
+	load_fast #1
+	arg 0
+	load_fast #0
+	call
+	delete_name_scoped #0
+	load_fast #1
+	ret
+end
+function __fn0
+	arg 0
+	store z
+	load_fast self
+	printn *
+	void
+	void
+	ret
+end
+function __module__
+	make_function .\int_promise.mmm#Dog_0
+	store_fast Dog
+	load Dog
+	store_fast #1
+	string Scout
+	store_fast #2
+	load_fast #2
+	load_fast #1
+	call
+	store x
+	load Dog
+	store_fast #1
+	string Muna
+	store_fast #2
+	load_fast #2
+	load_fast #1
+	call
+	store y
+	make_function ./int_promise.mmm#__fn0
+	store idk
+	load x
+	store_fast #1
+	load_fast #1
+	lookup play
+	store_fast #2
+	load y
+	store_fast #3
+	load_fast #3
+	ld_self #1
+	load_fast #2
+	call
+	void
+	load idk
+	store_fast #1
+	load_fast #1
+	call
+	void
+	ret
+end

--- a/examples/main/classes/int_promise.ms
+++ b/examples/main/classes/int_promise.ms
@@ -1,0 +1,9 @@
+class IntPromise {
+	resolve: fn(int)
+	reject: fn(str)
+
+	constructor(self, resolve: fn(int), reject: fn(str)) {
+		self.resolve = resolve
+		self.reject = reject
+	}
+}

--- a/examples/main/classes/many_classes.ms
+++ b/examples/main/classes/many_classes.ms
@@ -1,0 +1,25 @@
+class D {
+	fn get_value(self) -> int {
+		return 42
+	}
+}
+
+class C {
+	fn d(self) -> D {
+		return D()
+	}
+}
+
+class B {
+	fn c(self) -> C {
+		return C()
+	}
+}
+
+class A {
+	fn b(self) -> B {
+		return B()
+	}
+}
+
+print (A()).b().c().d().get_value()

--- a/examples/main/classes/return_self.ms
+++ b/examples/main/classes/return_self.ms
@@ -1,0 +1,11 @@
+class A {
+    value: int
+    constructor(self) {
+        self.value = 5
+    }
+    fn make_new_a(self) -> Self {
+        new: Self = Self()
+        new.value = 10
+        return new
+    } 
+}

--- a/examples/main/classes/return_self.ms
+++ b/examples/main/classes/return_self.ms
@@ -1,11 +1,31 @@
-class A {
-    value: int
-    constructor(self) {
-        self.value = 5
+
+
+class Dog {
+    name: str
+    
+    constructor(self, name: str) {
+        self.name = name
     }
-    fn make_new_a(self) -> Self {
-        new: Self = Self()
-        new.value = 10
-        return new
-    } 
+
+    fn play(self, other: Self) -> str {
+        return self.name + " is playing with " + other.name
+    }
+
+    fn strit(self) -> str {
+        return "DOG " + self.name
+    }
+
+    fn birds_and_bees(self, other: Self) -> Self {
+        return Self("child")
+	}
 }
+
+x = Dog("Scout")
+y = Dog("Muna")
+	
+print x.play(y)
+
+print x.strit()
+print y.strit()
+
+print x.strit()

--- a/examples/main/classes/return_self.ms
+++ b/examples/main/classes/return_self.ms
@@ -16,7 +16,7 @@ class Dog {
     }
 
     fn birds_and_bees(self, other: Self) -> Self {
-        return Self("child")
+        return Self(self.name + " & " + other.name + "'s kid")
 	}
 }
 
@@ -29,3 +29,5 @@ print x.strit()
 print y.strit()
 
 print x.strit()
+
+print x.birds_and_bees(y).strit()

--- a/examples/main/classes/self_type.ms
+++ b/examples/main/classes/self_type.ms
@@ -9,6 +9,11 @@ class A {
 		return Self(self.state + add)
 	}
 
+	fn clone_plus(self, add: Self) -> Self {
+		print self.state
+		return Self(1)
+	}
+
 	fn to_string(self) -> str {
 		return "A("+self.state+")"
 	}

--- a/examples/main/classes/self_type.ms
+++ b/examples/main/classes/self_type.ms
@@ -1,0 +1,17 @@
+class A {
+	state: int
+
+	constructor(self, state: int) {
+		self.state = state
+	}
+
+	fn clone_plus(self, add: int) -> Self {
+		return Self(self.state + add)
+	}
+
+	fn to_string(self) -> str {
+		return "A("+self.state+")"
+	}
+}
+
+a = A(5)


### PR DESCRIPTION
Added `Self` as a type, which is a special type that can only be used from within classes.

`Self` is special because it is also a keyword that can be used to reference a class' constructor from within its body.

```ts
class A {
    state: int

    constructor(self, state: int) {
        self.state = state
    }

    fn clone_plus(self, to_add: int) -> Self {
        return Self(self.state + to_add)
    }
}

a = A(10)
b = a.clone_plus(5)
assert b.state == 15
```